### PR TITLE
Added a feature to use filename as recipe name

### DIFF
--- a/lua/just/init.lua
+++ b/lua/just/init.lua
@@ -42,6 +42,10 @@ M.setup = function(_)
 
 		-- TODO handle multiple arguments
 		local recipeName = args.fargs[1]
+        if recipeName == "--use-filename" then
+            recipeName = utils.getFilename(vim.api.nvim_buf_get_name(0))
+            jobs.justRunAsync(recipeName, true)
+        end
 
 		utils.clearQuickfix()
 		utils.setQuickfixTitle("Just recipe: " .. args.fargs[1])

--- a/lua/just/utils.lua
+++ b/lua/just/utils.lua
@@ -97,4 +97,9 @@ function M.clearFile(file)
 	end
 end
 
+---Extracts a filename from a full path without the extension
+---@param path string Path to the file
+function M.getFilename(path)
+    return path:match(".+/(.-)%..+$") or path
+end
 return M


### PR DESCRIPTION
I added a feature to use the current filename as a recipe name.
If the file of the currently open file is, for example, test.md, then running 
```
:Just --use-filename
```
will run the test recipe.